### PR TITLE
Fix bare except swallowing KeyboardInterrupt during scanner discovery

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -39,7 +39,7 @@ def resolve_scanner():
                 if listener.info:
                     break
                 time.sleep(.1)
-        except:
+        except Exception:
             pass
     return listener.info
 


### PR DESCRIPTION
## Summary

- Changes `except:` to `except Exception:` in `resolve_scanner()`
- `bare except` catches `KeyboardInterrupt` and `SystemExit`, making Ctrl+C silently ignored for up to 10 seconds during scanner discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)