### PR TITLE
Fix job UUID extraction failing when Location header has trailing slash

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -161,7 +161,7 @@ def main():
     resp.raise_for_status()
 
     job_uri = resp.headers['location']
-    job_uuid = job_uri.split('/')[-1]
+    job_uuid = job_uri.rstrip('/').split('/')[-1]
     while True:
         status, jobinfo = get_status(job_uuid=job_uuid)
         if args.debug:


### PR DESCRIPTION
## Summary

- Strips trailing slash from the `Location` header value before extracting the job UUID
- Without this, scanners that return a trailing slash (e.g. `.../jobs/abc123/`) would produce an empty UUID, causing `get_status()` to never find the job and raise `RuntimeError('Job not found')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)