### PR TITLE
Add Content-Type header to ScanJobs POST request

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -157,7 +157,7 @@ def main():
       <scan:YResolution>{args.resolution}</scan:YResolution>
     </scan:ScanSettings>
     '''
-    resp = session.post(f'{BASE}/ScanJobs', data=job)
+    resp = session.post(f'{BASE}/ScanJobs', data=job, headers={'Content-Type': 'text/xml'})
     resp.raise_for_status()
 
     job_uri = resp.headers['location']


### PR DESCRIPTION
## Summary

- Adds `Content-Type: text/xml` to the `POST /ScanJobs` request
- Without it, some scanners may reject or mishandle the XML body

🤖 Generated with [Claude Code](https://claude.com/claude-code)