### PR TITLE
Separate CLI from core logic; migrate argparse to click

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import datetime
+import os
+import subprocess
+import sys
+
+import click
+
+from scanner import resolve_scanner, scan
+
+
+@click.command()
+@click.argument('filename')
+@click.option('--source', '-S', type=click.Choice(['feeder', 'flatbed', 'automatic']), default='automatic', show_default=True)
+@click.option('--grayscale', '-g', is_flag=True, help='Scan in grayscale instead of RGB')
+@click.option('--resolution', '-r', type=click.Choice(['75', '100', '200', '300', '600']), default='200', show_default=True)
+@click.option('--duplex', '-D', is_flag=True, help='Enable duplex (double-sided) scanning')
+@click.option('--today', '-t', is_flag=True, help='Prepend date to filename in ISO format')
+@click.option('--no-open', '-o', 'no_open', is_flag=True, help="Don't open the PDF after scanning")
+@click.option('--quiet', '-q', is_flag=True, help='Suppress scanner name output')
+@click.option('--debug', '-d', is_flag=True, help='Print debugging information to stderr')
+def main(filename, source, grayscale, resolution, duplex, today, no_open, quiet, debug):
+    if today:
+        filename = datetime.date.today().isoformat() + '-' + filename
+
+    if not filename.endswith('.pdf'):
+        raise click.UsageError('File must have a .pdf extension')
+
+    if os.path.exists(filename):
+        raise click.UsageError(f'File {filename} already exists')
+
+    info = resolve_scanner()
+    if not info:
+        click.echo('No scanner found', err=True)
+        sys.exit(1)
+
+    if not quiet:
+        suffix = '._uscan._tcp.local.'
+        name = info.name
+        if name.endswith(suffix):
+            name = name[:-len(suffix)]
+        click.echo(f'Using {name}')
+
+    success = scan(
+        info,
+        source=source,
+        grayscale=grayscale,
+        resolution=int(resolution),
+        duplex=duplex,
+        output_path=filename,
+        debug=debug,
+    )
+
+    if not success:
+        sys.exit(1)
+
+    if not no_open:
+        subprocess.run(['open', filename])
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scanner.py
+++ b/scanner.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 
-import argparse
-import sys
 import json
+import sys
 import time
-import subprocess
-import os
-import datetime
 
 import requests
 import xmltodict
@@ -30,10 +26,10 @@ def resolve_scanner():
 
         def add_service(self, zeroconf, type, name):
             self.info = zeroconf.get_service_info(type, name)
+
     with zeroconf.Zeroconf() as zc:
         listener = ZCListener()
-        zeroconf.ServiceBrowser(
-            zc, "_uscan._tcp.local.", listener=listener)
+        zeroconf.ServiceBrowser(zc, "_uscan._tcp.local.", listener=listener)
         try:
             for i in range(0, 10 * 10):
                 if listener.info:
@@ -44,104 +40,65 @@ def resolve_scanner():
     return listener.info
 
 
-def main():
-    parser = argparse.ArgumentParser()
+def _get_status(session, base, job_uuid=None):
+    resp = session.get(f'{base}/ScannerStatus')
+    resp.raise_for_status()
+    status = xmltodict.parse(
+        resp.text, force_list=('scan:JobInfo'))['scan:ScannerStatus']
+    if job_uuid is None:
+        return status, None
 
-    parser.add_argument(
-        '--source', '-S',
-        choices=['feeder', 'flatbed', 'automatic'], default='automatic')
-    parser.add_argument('--grayscale', '-g', action='store_true')
-    parser.add_argument(
-        '--resolution', '-r', type=int, default=200,
-        choices=[75, 100, 200, 300, 600])
-    parser.add_argument('--debug', '-d', action='store_true')
-    parser.add_argument('--no-open', '-o', action='store_false', dest='open')
-    parser.add_argument('--quiet', '-q', action='store_true')
-    parser.add_argument('--duplex', '-D', action='store_true')
-    parser.add_argument('--today', '-t', action='store_true',
-                        help='Prepend date to file name in ISO format')
-    parser.add_argument('filename')
+    uuid_prefix = "urn:uuid:"  # Seen in a Brother MFC device
+    for jobinfo in status['scan:Jobs']['scan:JobInfo']:
+        current_uuid = jobinfo['pwg:JobUuid']
+        if current_uuid.startswith(uuid_prefix):
+            current_uuid = current_uuid[len(uuid_prefix):]
+        if current_uuid == job_uuid:
+            return status, jobinfo
+    raise RuntimeError('Job not found')
 
-    args = parser.parse_args()
 
-    if args.today:
-        args.filename = (
-            datetime.date.today().isoformat() + '-' + args.filename)
-
-    if not args.filename.endswith('.pdf'):
-        print('File must have a .pdf extension')
-        sys.exit(1)
-
-    # Check if the file already exists
-    if os.path.exists(args.filename):
-        print(f'File {args.filename} already exists')
-        sys.exit(1)
-
-    info = resolve_scanner()
-    if not info:
-        print('No scanner found')
-        sys.exit(1)
+def scan(info, *, source, grayscale, resolution, duplex, output_path, debug=False):
+    '''
+    Perform a scan and write the result as a PDF to output_path.
+    Returns True on success, False on failure.
+    '''
     props = info.properties
-    if not args.quiet:
-        suffix = '._uscan._tcp.local.'
-        name = info.name
-        if info.name.endswith(suffix):
-            name = info.name[:-len(suffix)]
-        print(f'Using {name}')
-    if args.duplex and props[b'duplex'] != b'T':
+
+    if duplex and props.get(b'duplex') != b'T':
         print('Duplex not supported', file=sys.stderr)
-        sys.exit(1)
+        return False
 
     session = requests.Session()
 
-    if args.debug:
+    if debug:
         print(info, file=sys.stderr)
 
     rs = props[b'rs'].decode()
     if rs[0] != '/':
         rs = '/' + rs
-    BASE = f'http://{info.server}:{info.port}{rs}'
-    if args.debug:
-        print(BASE, file=sys.stderr)
+    base = f'http://{info.server}:{info.port}{rs}'
 
-    def get_status(job_uuid=None):
-        resp = session.get(f'{BASE}/ScannerStatus')
-        resp.raise_for_status()
-        status = xmltodict.parse(
-            resp.text, force_list=('scan:JobInfo'))['scan:ScannerStatus']
-        if job_uuid is None:
-            return status, None
+    if debug:
+        print(base, file=sys.stderr)
 
-        uuid_prefix = "urn:uuid:"  # Seen in a Brother MFC device
-        for jobinfo in status['scan:Jobs']['scan:JobInfo']:
-            current_uuid = jobinfo['pwg:JobUuid']
-            if current_uuid.startswith(uuid_prefix):
-                current_uuid = current_uuid[len(uuid_prefix):]
-
-            if current_uuid == job_uuid:
-                return status, jobinfo
-        raise RuntimeError('Job not found')
-
-    resp = session.get(f'{BASE}/ScannerCapabilities')
+    resp = session.get(f'{base}/ScannerCapabilities')
     resp.raise_for_status()
-    if args.debug:
+    if debug:
         print(resp.text, file=sys.stderr)
 
-    status, _ = get_status()
+    status, _ = _get_status(session, base)
     if status['pwg:State'] != 'Idle':
         print('Scanner is not idle', file=sys.stderr)
-        return 1
+        return False
 
-    source = {
+    source_xml = {
         'automatic': '',
         'feeder': '<pwg:InputSource>Feeder</pwg:InputSource>',
         'flatbed': '<pwg:InputSource>Flatbed</pwg:InputSource>',
-    }[args.source]
+    }[source]
 
-    if args.grayscale:
-        color = 'Grayscale8'
-    else:
-        color = 'RGB24'
+    color = 'Grayscale8' if grayscale else 'RGB24'
 
     job = f'''<?xml version="1.0" encoding="UTF-8"?>
     <scan:ScanSettings xmlns:scan="http://schemas.hp.com/imaging/escl/2011/05/03"
@@ -149,21 +106,22 @@ def main():
       <pwg:Version>2.0</pwg:Version>
       <scan:Intent>TextAndGraphic</scan:Intent>
       <pwg:DocumentFormat>application/pdf</pwg:DocumentFormat>
-      {source}
+      {source_xml}
       <scan:ColorMode>{color}</scan:ColorMode>
-      <scan:Duplex>{str(args.duplex).lower()}</scan:Duplex>
-      <scan:XResolution>{args.resolution}</scan:XResolution>
-      <scan:YResolution>{args.resolution}</scan:YResolution>
+      <scan:Duplex>{str(duplex).lower()}</scan:Duplex>
+      <scan:XResolution>{resolution}</scan:XResolution>
+      <scan:YResolution>{resolution}</scan:YResolution>
     </scan:ScanSettings>
     '''
-    resp = session.post(f'{BASE}/ScanJobs', data=job, headers={'Content-Type': 'text/xml'})
+    resp = session.post(f'{base}/ScanJobs', data=job, headers={'Content-Type': 'text/xml'})
     resp.raise_for_status()
 
     job_uri = resp.headers['location']
     job_uuid = job_uri.rstrip('/').split('/')[-1]
+
     while True:
-        status, jobinfo = get_status(job_uuid=job_uuid)
-        if args.debug:
+        status, jobinfo = _get_status(session, base, job_uuid=job_uuid)
+        if debug:
             print(json.dumps(jobinfo, indent=2), file=sys.stderr)
 
         resp = session.get(f'{job_uri}/NextDocument')
@@ -172,28 +130,16 @@ def main():
             break
         resp.raise_for_status()
 
-        with open(args.filename, 'wb') as f:
+        with open(output_path, 'wb') as f:
             f.write(resp.content)
 
         if status['pwg:State'] != 'Processing':
             break
         time.sleep(1)
 
-    status, jobinfo = get_status(job_uuid=job_uuid)
+    status, jobinfo = _get_status(session, base, job_uuid=job_uuid)
     job_reason = jobinfo['pwg:JobStateReasons']['pwg:JobStateReason']
-    if args.debug:
+    if debug:
         print(job_reason, file=sys.stderr)
-    if job_reason != 'JobCompletedSuccessfully':
-        return 1
 
-    if args.open:
-        subprocess.run(['open', args.filename])
-
-    return 0
-
-
-if __name__ == '__main__':
-    try:
-        sys.exit(main())
-    except KeyboardInterrupt:
-        sys.exit(130)
+    return job_reason == 'JobCompletedSuccessfully'

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,16 @@ setup(
     author='https://github.com/zegman, Pavel Kalvoda',
     author_email='me@pavelkalvoda.com',
     license='Apache',
-    py_modules=['scanner'],
+    py_modules=['scanner', 'cli'],
     install_requires=[
+        'click',
         'requests',
         'xmltodict',
         'zeroconf',
     ],
     entry_points={
         'console_scripts': [
-            'escl-scan = scanner:main',
+            'escl-scan = cli:main',
         ],
     },
 )


### PR DESCRIPTION
## Summary

- `scanner.py` is now a pure library: `resolve_scanner()` and `scan()` (explicit keyword args, returns `True`/`False`). `_get_status()` is extracted from its nested closure into a module-level private function.
- `cli.py` is the new entry point: handles click options, input validation (`.pdf` extension, file existence, `--today`), scanner name display, and post-scan `open`.
- `setup.py`: added `click` dependency, entry point changed from `scanner:main` to `cli:main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)