### PR TITLE
Add version info to package and CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7,10 +7,11 @@ import sys
 
 import click
 
-from scanner import resolve_scanner, scan
+from scanner import __version__, resolve_scanner, scan
 
 
 @click.command()
+@click.version_option(version=__version__)
 @click.argument('filename')
 @click.option('--source', '-S', type=click.Choice(['feeder', 'flatbed', 'automatic']), default='automatic', show_default=True)
 @click.option('--grayscale', '-g', is_flag=True, help='Scan in grayscale instead of RGB')

--- a/scanner.py
+++ b/scanner.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+__version__ = '0.2.1'
+
 import json
 import sys
 import time


### PR DESCRIPTION
## Summary

- `__version__ = '0.2.1'` defined in `scanner.py` as the single source of truth
- `cli.py` imports it and passes it to `@click.version_option()`, exposing `escl-scan --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)