### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ Known to work with at least:
 - HP OfficeJet Pro 9010 series
 
 ## Installation
-From PyPI:
+
+From [PyPI](https://pypi.org/project/escl-scanner-cli/) using [pipx](https://pipx.pypa.io):
 ```
 pipx install escl-scanner-cli
 ```
 
-Locally:
+From source (latest development version):
 ```
-pip install .
+pipx install . --force
 ```
 
 ## Publishing to PyPI


### PR DESCRIPTION
## Summary

- Added links to PyPI package page and pipx website
- Replaced bare `pip install .` with `pipx install . --force` for installing from source, consistent with the pipx-first approach and clarifying that `--force` is needed to override an existing installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)