### PR TITLE
Port flatbed fix, 503 retry, and improved discovery from upstream

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -17,8 +17,16 @@ See: https://mopria.org/MopriaeSCLSpecDownload.php
 
 HTTP_TIMEOUT_SECONDS = 30
 
+DISCOVERY_TIMEOUT_SECONDS = 30.0
+DISCOVERY_RETRIES = 2
+DISCOVERY_RETRY_DELAY_SECONDS = 0.5
+DISCOVERY_SLEEP_SECONDS = 0.1
 
-def resolve_scanner():
+
+def resolve_scanner(
+    timeout_seconds=DISCOVERY_TIMEOUT_SECONDS,
+    retries=DISCOVERY_RETRIES,
+):
     class ZCListener:
         def __init__(self):
             self.info = None
@@ -32,21 +40,25 @@ def resolve_scanner():
         def add_service(self, zeroconf, type, name):
             self.info = zeroconf.get_service_info(type, name)
 
-    with zeroconf.Zeroconf() as zc:
-        listener = ZCListener()
-        zeroconf.ServiceBrowser(zc, "_uscan._tcp.local.", listener=listener)
-        try:
-            for i in range(0, 10 * 10):
-                if listener.info:
-                    break
-                time.sleep(.1)
-        except Exception:
-            pass
-    return listener.info
+    for attempt in range(retries):
+        with zeroconf.Zeroconf() as zc:
+            listener = ZCListener()
+            zeroconf.ServiceBrowser(zc, "_uscan._tcp.local.", listener=listener)
+            deadline = time.monotonic() + timeout_seconds
+            try:
+                while time.monotonic() < deadline:
+                    if listener.info:
+                        return listener.info
+                    time.sleep(DISCOVERY_SLEEP_SECONDS)
+            except Exception:
+                pass
+        if attempt + 1 < retries:
+            time.sleep(DISCOVERY_RETRY_DELAY_SECONDS)
+    return None
 
 
 def _get_status(session, base, job_uuid=None):
-    resp = session.get(f'{base}/ScannerStatus', timeout=HTTP_TIMEOUT)
+    resp = session.get(f'{base}/ScannerStatus', timeout=HTTP_TIMEOUT_SECONDS)
     resp.raise_for_status()
     status = xmltodict.parse(
         resp.text, force_list=('scan:JobInfo'))['scan:ScannerStatus']
@@ -91,7 +103,7 @@ def scan(info, *, source, grayscale, resolution, duplex, output_path, debug=Fals
     if debug:
         print(base, file=sys.stderr)
 
-    resp = session.get(f'{base}/ScannerCapabilities', timeout=HTTP_TIMEOUT)
+    resp = session.get(f'{base}/ScannerCapabilities', timeout=HTTP_TIMEOUT_SECONDS)
     resp.raise_for_status()
     if debug:
         print(resp.text, file=sys.stderr)
@@ -104,7 +116,7 @@ def scan(info, *, source, grayscale, resolution, duplex, output_path, debug=Fals
     source_xml = {
         'automatic': '',
         'feeder': '<pwg:InputSource>Feeder</pwg:InputSource>',
-        'flatbed': '<pwg:InputSource>Flatbed</pwg:InputSource>',
+        'flatbed': '<pwg:InputSource>Platen</pwg:InputSource>',
     }[source]
 
     color = 'Grayscale8' if grayscale else 'RGB24'
@@ -122,7 +134,7 @@ def scan(info, *, source, grayscale, resolution, duplex, output_path, debug=Fals
       <scan:YResolution>{resolution}</scan:YResolution>
     </scan:ScanSettings>
     '''
-    resp = session.post(f'{base}/ScanJobs', data=job, headers={'Content-Type': 'text/xml'}, timeout=HTTP_TIMEOUT)
+    resp = session.post(f'{base}/ScanJobs', data=job, headers={'Content-Type': 'text/xml'}, timeout=HTTP_TIMEOUT_SECONDS)
     resp.raise_for_status()
 
     job_uri = resp.headers['location']
@@ -136,7 +148,18 @@ def scan(info, *, source, grayscale, resolution, duplex, output_path, debug=Fals
             if debug:
                 print(json.dumps(jobinfo, indent=2), file=sys.stderr)
 
-            resp = session.get(f'{job_uri}/NextDocument', timeout=HTTP_TIMEOUT)
+            retry_count = 0
+            while True:
+                resp = session.get(f'{job_uri}/NextDocument', timeout=HTTP_TIMEOUT_SECONDS)
+                if resp.status_code != 503:
+                    break
+                retry_count += 1
+                if debug:
+                    print(f'503 from NextDocument (attempt {retry_count})', file=sys.stderr)
+                if retry_count >= 100:
+                    print('Scanner returned 503 for NextDocument', file=sys.stderr)
+                    resp.raise_for_status()
+                time.sleep(1)
             if resp.status_code == 404:
                 # We are done
                 break


### PR DESCRIPTION
## Summary

Porting three improvements from [zegman/scanner-cli](https://github.com/zegman/scanner-cli):

- **Flatbed fix**: `InputSource` was `Flatbed`; correct eSCL spec value is `Platen`
- **503 retry**: `NextDocument` can transiently return 503 while the scanner is processing; now retries up to 100 times with 1s delay before failing
- **Discovery improvements**: replaced fixed-iteration loop with `time.monotonic()` deadline, added configurable retries (default 2) with delay between attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)